### PR TITLE
[Draft] Pydantic implementation of circuit metadata Part 2

### DIFF
--- a/AutoCkt/Ckt/eval_engines/TwoStageOpAmp.py
+++ b/AutoCkt/Ckt/eval_engines/TwoStageOpAmp.py
@@ -10,26 +10,8 @@ from .params import TbParams
 from .pdk import nmos, pmos
 
 
-@h.paramclass
-class OpAmpParams:
-    """Parameter class"""
-
-    wp1 = h.Param(dtype=int, desc="Width of PMOS mp1", default=10)
-    wp2 = h.Param(dtype=int, desc="Width of PMOS mp2", default=10)
-    wp3 = h.Param(dtype=int, desc="Width of PMOS mp3", default=4)
-    wn1 = h.Param(dtype=int, desc="Width of NMOS mn1", default=38)
-    wn2 = h.Param(dtype=int, desc="Width of NMOS mn2", default=38)
-    wn3 = h.Param(dtype=int, desc="Width of NMOS mn3", default=9)
-    wn4 = h.Param(dtype=int, desc="Width of NMOS mn4", default=20)
-    wn5 = h.Param(dtype=int, desc="Width of NMOS mn5", default=60)
-    VDD = h.Param(dtype=h.Scalar, desc="VDD voltage", default=1.2)
-    CL = h.Param(dtype=h.Scalar, desc="CL capacitance", default=1e-11)
-    Cc = h.Param(dtype=h.Scalar, desc="Cc capacitance", default=3e-12)
-    ibias = h.Param(dtype=h.Scalar, desc="ibias current", default=3e-5)
-
-
 @h.generator
-def OpAmp(p: OpAmpParams) -> h.Module:
+def OpAmp(p: hdl21_paramclass[OpAmpInput]) -> h.Module:
     """# Two stage OpAmp"""
 
     @h.module
@@ -76,18 +58,8 @@ def opamp_inner(inp: OpAmpInput) -> OpAmpOutput:
 
     # Convert our input into `OpAmpParams`
     # FIXME: @king-han gonna clean all this conversion stuff up
-    params = OpAmpParams(
-        wp1=inp.mp1,
-        wn1=inp.mn1,
-        wp3=inp.mp3,
-        wn3=inp.mn3,
-        wn4=inp.mn4,
-        wn5=inp.mn5,
-        Cc=inp.cc,
-        # FIXME Extra, don't need?
-        wp2=inp.mp1,
-        wn2=inp.mn1,
-    )
+    # FIXME the names of the params are not the same, need to change above
+    params = as_hdl21_paramclass(inp)
 
     # Create a testbench, simulate it, and return the metrics!
     opamp = OpAmp(params)

--- a/AutoCkt/Shared/autockt_shared/opamp.py
+++ b/AutoCkt/Shared/autockt_shared/opamp.py
@@ -17,6 +17,51 @@ from .cktopt import (
 )
 
 
+from dataclasses import asdict
+
+
+def as_hdl21_paramclass(data):
+    """
+    Convert a dataclass to a Hdl21 parameter class
+    """
+    return hdl21_paramclass[type(data)](
+        **asdict(data),
+    )
+
+
+def as_param_specs(dataclass_type):
+    """
+    Convert a dataclass to a ParamSpecs
+    """
+    return ParamSpecs(
+        [
+            ParamSpec(
+                name=field.name,
+                range=(field.default.ge, field.default.le),
+                step=field.default.extra["step"],
+                init=field.default.default,
+            )
+            for field in dataclass_type.__dataclass_fields__.values()
+        ]
+    )
+
+
+def as_target_specs(dataclass_type):
+    """
+    Convert a dataclass to a MetricSpecs
+    """
+    return MetricSpecs(
+        [
+            MetricSpec(
+                name=field.name,
+                range=(field.default.ge, field.default.le),
+                normalize=field.default.extra["normalize"],
+            )
+            for field in dataclass_type.__dataclass_fields__.values()
+        ]
+    )
+
+
 @dataclass
 class OpAmpInput:
     """
@@ -121,25 +166,8 @@ auto_ckt_sim_hdl21 = Rpc(
 
 
 circuit_optimization = CircuitOptimization(
-    params=ParamSpecs(
-        [
-            ParamSpec("mp1", (1, 100), step=1, init=34),
-            ParamSpec("mn1", (1, 100), step=1, init=34),
-            ParamSpec("mp3", (1, 100), step=1, init=34),
-            ParamSpec("mn3", (1, 100), step=1, init=34),
-            ParamSpec("mn4", (1, 100), step=1, init=34),
-            ParamSpec("mn5", (1, 100), step=1, init=15),
-            ParamSpec("cc", (0.1e-12, 10.0e-12), step=0.1e-12, init=2.1e-12),
-        ]
-    ),
-    specs=MetricSpecs(
-        [
-            MetricSpec("gain", (200, 400), normalize=350),
-            MetricSpec("ugbw", (1.0e6, 2.5e7), normalize=9.5e5),
-            MetricSpec("phm", (60, 60.0000001), normalize=60),
-            MetricSpec("ibias", (0.0001, 0.01), normalize=0.001),
-        ]
-    ),
+    params=as_param_specs(OpAmpInput),
+    specs=as_target_specs(OpAmpOutput),
     input_type=OpAmpInput,
     output_type=OpAmpOutput,
     simulation=auto_ckt_sim,


### PR DESCRIPTION
@HarryYanH The simplification of the definitions should look something like this. I did it for OpAmp, but I have not tested it yet.